### PR TITLE
feat: add booking creation and retrieval API endpoints

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,10 +1,12 @@
 const express = require('express');
 const mongoose = require('mongoose');
+const cors = require('cors');
 
 const app = express();
 const port = process.env.PORT || 5000;
 
 // Middleware
+app.use(cors());
 app.use(express.json());
 
 // DB Config
@@ -58,6 +60,34 @@ const Review = mongoose.model('Review', ReviewSchema);
 app.get('/', (req, res) => {
   res.send('Server is running');
 });
+
+// @route   POST api/bookings
+// @desc    Create a booking
+// @access  Public
+app.post('/api/bookings', (req, res) => {
+  const newBooking = new Booking({
+    farm: req.body.farm,
+    user: req.body.user,
+    date: req.body.date,
+    time: req.body.time,
+  });
+
+  newBooking.save()
+    .then(booking => res.status(201).json(booking))
+    .catch(err => res.status(400).json({ error: 'Failed to create booking', details: err }));
+});
+
+// @route   GET api/bookings/user/:userId
+// @desc    Get all bookings for a specific user
+// @access  Public
+app.get('/api/bookings/user/:userId', (req, res) => {
+  Booking.find({ user: req.params.userId })
+    .populate('farm', ['name', 'location']) // Populate with farm name and location
+    .sort({ date: -1 })
+    .then(bookings => res.json(bookings))
+    .catch(err => res.status(404).json({ error: 'No bookings found for this user', details: err }));
+});
+
 
 app.listen(port, () => {
   console.log(`Server is running on port ${port}`);

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "cors": "^2.8.5",
         "express": "^4.19.2",
         "mongoose": "^8.5.1"
       }
@@ -162,6 +163,19 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -697,6 +711,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/server/package.json
+++ b/server/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "cors": "^2.8.5",
     "express": "^4.19.2",
     "mongoose": "^8.5.1"
   }

--- a/server/server.log
+++ b/server/server.log
@@ -1,0 +1,1 @@
+Server is running on port 5000


### PR DESCRIPTION
This commit introduces the initial backend functionality for the booking feature.

- Adds a `POST /api/bookings` endpoint to allow you to create new bookings.
- Adds a `GET /api/bookings/user/:userId` endpoint to retrieve all of your bookings, populating farm details.
- Enables CORS on the Express server to allow requests from the frontend client.