### PR TITLE
Fix: Vercelデプロイのビルド失敗を修正

### DIFF
--- a/client/app/farm/[id]/page.tsx
+++ b/client/app/farm/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import Image from 'next/image';
-import { useRouter } from 'next/navigation
+import { useRouter } from 'next/navigation';
 import { farms } from '../../data';
 
 export default function FarmDetailsPage({ params }: { params: { id: string } }) {

--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -1,15 +1,10 @@
-@import "tailwindcss";
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 :root {
   --background: #ffffff;
   --foreground: #171717;
-}
-
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
 }
 
 @media (prefers-color-scheme: dark) {

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
Vercelへのデプロイが失敗する原因となっていた複数の問題を修正しました。

主な修正点は以下の通りです:
1.  `client/app/farm/[id]/page.tsx`にあった`useRouter`のインポート文の構文エラーを修正しました。
2.  不足していた`client/tailwind.config.js`ファイルを作成し、Tailwind CSSが正しく設定されるようにしました。
3.  `client/app/globals.css`内の`@import "tailwindcss";`という不正な記述を、標準的な`@tailwind`ディレクティブに置き換えました。

これらの修正により、`next build`が正常に完了するようになり、デプロイが成功する見込みです。