### PR TITLE
fix: 外部ドメインの画像が表示されない問題を修正

### DIFF
--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -1,5 +1,21 @@
+/** @type {import('next').NextConfig} */
 const nextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'images.unsplash.com',
+        port: '',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'via.placeholder.com',
+        port: '',
+        pathname: '/**',
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Next.jsのImageコンポーネントで外部ドメインの画像を使用するために、`next.config.mjs`に必要な設定を追加しました。

`images.unsplash.com` と `via.placeholder.com` からの画像読み込みを許可するように`remotePatterns`を設定しました。これにより、ヒーローセクションの背景画像や農園リストの画像が正しく表示されるようになります。