### PR TITLE
fix: Unsplash画像のpathname設定を修正

### DIFF
--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -6,7 +6,7 @@ const nextConfig = {
         protocol: 'https',
         hostname: 'images.unsplash.com',
         port: '',
-        pathname: '/**',
+        pathname: '/photo-**',
       },
       {
         protocol: 'https',


### PR DESCRIPTION
一部のUnsplash画像が表示されない問題を解決するため、`next.config.mjs`の`remotePatterns`設定を修正しました。

`images.unsplash.com`ホストに対する`pathname`を、より具体的な`/photo-**`パターンに変更しました。これにより、Next.jsが画像URLをより確実に認識し、全ての農園画像が正しく表示されるようになります。